### PR TITLE
Refactor translations

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -2,23 +2,13 @@ import { Button } from "@/components/ui/button";
 import { Mail } from "lucide-react";
 import { FaInstagram, FaYoutube } from "react-icons/fa";
 import { SiTiktok } from "react-icons/si";
+import { Language, footerTranslations } from "@/lib/i18n";
 
 interface FooterProps {
-  language: 'en' | 'it';
+  language: Language;
 }
 
-const translations = {
-  en: {
-    contact: "Get in Touch",
-    rights: "© 2024 LOELASH. All rights reserved.",
-    email: "info@loelash.com"
-  },
-  it: {
-    contact: "Mettiti in Contatto",
-    rights: "© 2024 LOELASH. Tutti i diritti riservati.",
-    email: "info@loelash.com"
-  }
-};
+const translations = footerTranslations;
 
 export const Footer = ({ language }: FooterProps) => {
   const t = translations[language];

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,27 +1,13 @@
 import { Button } from "@/components/ui/button";
+import { Language, headerTranslations } from "@/lib/i18n";
 
 interface HeaderProps {
-  language: 'en' | 'it';
-  onLanguageChange: (lang: 'en' | 'it') => void;
+  language: Language;
+  onLanguageChange: (lang: Language) => void;
 }
 
-const translations = {
-  en: {
-    music: "Music",
-    services: "Services", 
-    contact: "Contact",
-    cta: "Let's Work!"
-  },
-  it: {
-    music: "Musica",
-    services: "Servizi",
-    contact: "Contatto", 
-    cta: "Lavoriamo!"
-  }
-};
-
 export const Header = ({ language, onLanguageChange }: HeaderProps) => {
-  const t = translations[language];
+  const t = headerTranslations[language];
 
   return (
     <header className="fixed top-0 left-0 right-0 z-50 bg-background backdrop-blur-md border-b border-border">

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,59 +1,11 @@
 import { useState } from "react";
+import { Language, heroTranslations } from "@/lib/i18n";
 
 interface HeroSectionProps {
-  language: 'en' | 'it';
+  language: Language;
 }
 
-const translations = {
-  en: {
-    services: {
-      mixing: {
-        title: "Mixing",
-        description: "Transform your raw tracks into polished, professional recordings with precise balance and clarity.",
-        cta: "Get Mixed"
-      },
-      mastering: {
-        title: "Mastering", 
-        description: "Give your music the final touch with industry-standard mastering for streaming and physical release.",
-        cta: "Get Mastered"
-      },
-      production: {
-        title: "Production",
-        description: "From concept to completion, bring your musical vision to life with professional production.",
-        cta: "Start Producing"
-      },
-      musicianship: {
-        title: "Musicianship",
-        description: "Expert session work and musical arrangement to enhance your creative projects.",
-        cta: "Collaborate"
-      }
-    }
-  },
-  it: {
-    services: {
-      mixing: {
-        title: "Mixing",
-        description: "Trasforma le tue tracce grezze in registrazioni professionali con equilibrio e chiarezza precisi.",
-        cta: "Fai Mixare"
-      },
-      mastering: {
-        title: "Mastering",
-        description: "Dai alla tua musica il tocco finale con mastering professionale per streaming e rilascio fisico.",
-        cta: "Fai Masterizzare"
-      },
-      production: {
-        title: "Produzione",
-        description: "Dal concetto al completamento, porta in vita la tua visione musicale con produzione professionale.",
-        cta: "Inizia a Produrre"
-      },
-      musicianship: {
-        title: "Musicianship",
-        description: "Lavoro di sessione esperto e arrangiamento musicale per migliorare i tuoi progetti creativi.",
-        cta: "Collabora"
-      }
-    }
-  }
-};
+const translations = heroTranslations;
 
 export const HeroSection = ({ language }: HeroSectionProps) => {
   const [hoveredQuadrant, setHoveredQuadrant] = useState<string | null>(null);

--- a/src/components/SubHeader.tsx
+++ b/src/components/SubHeader.tsx
@@ -1,17 +1,10 @@
+import { Language, subHeaderTranslations } from "@/lib/i18n";
+
 interface SubHeaderProps {
-  language: 'en' | 'it';
+  language: Language;
 }
 
-const translations = {
-  en: {
-    headline: "Craft your sound. Shape your future.",
-    subline: "Mixing. Mastering. Musicianship."
-  },
-  it: {
-    headline: "Crea il tuo suono. Modella il tuo futuro.",
-    subline: "Mixing. Mastering. Musicianship."
-  }
-};
+const translations = subHeaderTranslations;
 
 export const SubHeader = ({ language }: SubHeaderProps) => {
   const t = translations[language];

--- a/src/components/TrustSection.tsx
+++ b/src/components/TrustSection.tsx
@@ -1,31 +1,10 @@
+import { Language, trustTranslations } from "@/lib/i18n";
+
 interface TrustSectionProps {
-  language: 'en' | 'it';
+  language: Language;
 }
 
-const translations = {
-  en: {
-    title: "Trusted by artists worldwide",
-    clients: [
-      "Universal Music Group",
-      "Sony Music",
-      "Independent Artists",
-      "Emerging Talents",
-      "Major Labels",
-      "Music Producers"
-    ]
-  },
-  it: {
-    title: "La fiducia di artisti in tutto il mondo",
-    clients: [
-      "Universal Music Group", 
-      "Sony Music",
-      "Artisti Indipendenti",
-      "Talenti Emergenti",
-      "Etichette Principali",
-      "Produttori Musicali"
-    ]
-  }
-};
+const translations = trustTranslations;
 
 export const TrustSection = ({ language }: TrustSectionProps) => {
   const t = translations[language];

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,0 +1,116 @@
+export type Language = 'en' | 'it';
+
+export const headerTranslations = {
+  en: {
+    music: 'Music',
+    services: 'Services',
+    contact: 'Contact',
+    cta: "Let's Work!"
+  },
+  it: {
+    music: 'Musica',
+    services: 'Servizi',
+    contact: 'Contatto',
+    cta: 'Lavoriamo!'
+  }
+};
+
+export const subHeaderTranslations = {
+  en: {
+    headline: 'Craft your sound. Shape your future.',
+    subline: 'Mixing. Mastering. Musicianship.'
+  },
+  it: {
+    headline: 'Crea il tuo suono. Modella il tuo futuro.',
+    subline: 'Mixing. Mastering. Musicianship.'
+  }
+};
+
+export const heroTranslations = {
+  en: {
+    services: {
+      mixing: {
+        title: 'Mixing',
+        description: 'Transform your raw tracks into polished, professional recordings with precise balance and clarity.',
+        cta: 'Get Mixed'
+      },
+      mastering: {
+        title: 'Mastering',
+        description: 'Give your music the final touch with industry-standard mastering for streaming and physical release.',
+        cta: 'Get Mastered'
+      },
+      production: {
+        title: 'Production',
+        description: 'From concept to completion, bring your musical vision to life with professional production.',
+        cta: 'Start Producing'
+      },
+      musicianship: {
+        title: 'Musicianship',
+        description: 'Expert session work and musical arrangement to enhance your creative projects.',
+        cta: 'Collaborate'
+      }
+    }
+  },
+  it: {
+    services: {
+      mixing: {
+        title: 'Mixing',
+        description: 'Trasforma le tue tracce grezze in registrazioni professionali con equilibrio e chiarezza precisi.',
+        cta: 'Fai Mixare'
+      },
+      mastering: {
+        title: 'Mastering',
+        description: 'Dai alla tua musica il tocco finale con mastering professionale per streaming e rilascio fisico.',
+        cta: 'Fai Masterizzare'
+      },
+      production: {
+        title: 'Produzione',
+        description: 'Dal concetto al completamento, porta in vita la tua visione musicale con produzione professionale.',
+        cta: 'Inizia a Produrre'
+      },
+      musicianship: {
+        title: 'Musicianship',
+        description: 'Lavoro di sessione esperto e arrangiamento musicale per migliorare i tuoi progetti creativi.',
+        cta: 'Collabora'
+      }
+    }
+  }
+};
+
+export const trustTranslations = {
+  en: {
+    title: 'Trusted by artists worldwide',
+    clients: [
+      'Universal Music Group',
+      'Sony Music',
+      'Independent Artists',
+      'Emerging Talents',
+      'Major Labels',
+      'Music Producers'
+    ]
+  },
+  it: {
+    title: 'La fiducia di artisti in tutto il mondo',
+    clients: [
+      'Universal Music Group',
+      'Sony Music',
+      'Artisti Indipendenti',
+      'Talenti Emergenti',
+      'Etichette Principali',
+      'Produttori Musicali'
+    ]
+  }
+};
+
+export const footerTranslations = {
+  en: {
+    contact: 'Get in Touch',
+    rights: '© 2024 LOELASH. All rights reserved.',
+    email: 'info@loelash.com'
+  },
+  it: {
+    contact: 'Mettiti in Contatto',
+    rights: '© 2024 LOELASH. Tutti i diritti riservati.',
+    email: 'info@loelash.com'
+  }
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -4,9 +4,10 @@ import { SubHeader } from "@/components/SubHeader";
 import { HeroSection } from "@/components/HeroSection";
 import { TrustSection } from "@/components/TrustSection";
 import { Footer } from "@/components/Footer";
+import type { Language } from "@/lib/i18n";
 
 const Index = () => {
-  const [language, setLanguage] = useState<'en' | 'it'>('en');
+  const [language, setLanguage] = useState<Language>('en');
 
   return (
     <div className="min-h-screen bg-background">


### PR DESCRIPTION
## Summary
- centralize translation data in `src/lib/i18n.ts`
- use the new `Language` type and translation constants in UI components

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*
- `npm run build:dev`


------
https://chatgpt.com/codex/tasks/task_e_688774ce13248320bfc726e5334a6d9b