### PR TITLE
Update AGENTS with translation guideline

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,5 +47,11 @@ You can edit this project in several ways:
 - shadcn-ui
 - Tailwind CSS
 
+## Translation Guidelines
+- The application currently supports English (`en`) and Italian (`it`).
+- Whenever you modify any user-facing text or add new UI features, update the
+  translation dictionaries in `src/lib/i18n.ts` so both languages stay
+  synchronized.
+
 ---
 For more details, see the README.md file or visit the Lovable documentation.


### PR DESCRIPTION
## Summary
- update AGENTS.md with new bilingual translation requirement

## Testing
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_68877ce8a7ec83208d050f3715fe9559