### PR TITLE
Add simple About section

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -1,0 +1,22 @@
+import { Language, aboutTranslations } from "@/lib/i18n";
+
+interface AboutSectionProps {
+  language: Language;
+}
+
+const translations = aboutTranslations;
+
+export const AboutSection = ({ language }: AboutSectionProps) => {
+  const t = translations[language];
+
+  return (
+    <section className="py-16">
+      <div className="container mx-auto px-6 flex flex-col md:flex-row gap-8">
+        <h2 className="text-2xl md:text-3xl font-semibold md:w-1/4">{t.title}</h2>
+        <p className="text-base text-muted-foreground md:w-3/4 max-w-prose">
+          {t.text}
+        </p>
+      </div>
+    </section>
+  );
+};

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -114,3 +114,14 @@ export const footerTranslations = {
     email: 'info@loelash.com'
   }
 };
+
+export const aboutTranslations = {
+  en: {
+    title: 'About',
+    text: "I'm Lorenzo (aka Loelash) - a London-based multi-instrumentalist, producer, DJ, and certified Apple Trainer. With over a decade of experience in music creation and performance, I blend classical training with modern production skills to support artists at every stage of their journey. Whether it's through tutoring, session work, engineering, or promotion, my mission"
+  },
+  it: {
+    title: 'Chi Sono',
+    text: 'Sono Lorenzo (alias Loelash) - un polistrumentista, produttore, DJ e Apple Trainer certificato con base a Londra. Con oltre un decennio di esperienza nella creazione e performance musicale, unisco la formazione classica alle moderne competenze di produzione per supportare gli artisti in ogni fase del loro percorso. Che si tratti di lezioni, session work, engineering o promozione, la mia missione'
+  }
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -3,6 +3,7 @@ import { Header } from "@/components/Header";
 import { SubHeader } from "@/components/SubHeader";
 import { HeroSection } from "@/components/HeroSection";
 import { TrustSection } from "@/components/TrustSection";
+import { AboutSection } from "@/components/AboutSection";
 import { Footer } from "@/components/Footer";
 import type { Language } from "@/lib/i18n";
 
@@ -15,6 +16,7 @@ const Index = () => {
       <SubHeader language={language} />
       <HeroSection language={language} />
       <TrustSection language={language} />
+      <AboutSection language={language} />
       <Footer language={language} />
     </div>
   );


### PR DESCRIPTION
## Summary
- add translations for new About section
- create AboutSection component
- show new AboutSection on homepage above the footer

## Testing
- `npm run build`
- `npm run lint` *(fails: Cannot read properties of undefined (reading 'allowShortCircuit'))*

------
https://chatgpt.com/codex/tasks/task_e_68877fafee448320882cd565b3c3857b