### PR TITLE
Left align subheader text

### DIFF
--- a/src/components/SubHeader.tsx
+++ b/src/components/SubHeader.tsx
@@ -11,7 +11,7 @@ export const SubHeader = ({ language }: SubHeaderProps) => {
 
   return (
     <section className="pt-24 pb-12 bg-background">
-      <div className="container mx-auto px-6 text-center">
+      <div className="container mx-auto px-6 text-left">
         <h1 className="text-4xl md:text-6xl lg:text-7xl font-bold text-foreground mb-4 tracking-tight">
           {t.headline}
         </h1>


### PR DESCRIPTION
## Summary
- tweak SubHeader alignment

## Testing
- `npm run lint` *(fails: cannot read property 'allowShortCircuit')*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68877fd747308320ba19f5df186b424d