### PR TITLE
Refactor links and translations

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Language, headerTranslations } from "@/lib/i18n";
+import { mailtoLink } from "@/lib/utils";
 
 interface HeaderProps {
   language: Language;
@@ -24,20 +25,20 @@ export const Header = ({ language, onLanguageChange }: HeaderProps) => {
 
           {/* Navigation */}
           <div className="hidden md:flex items-center space-x-4">
-            <a 
-              href="mailto:info@loelash.com?subject=Music Inquiry"
+            <a
+              href={mailtoLink('Music Inquiry')}
               className="px-4 py-2 rounded-full bg-background text-foreground hover:bg-muted transition-all duration-200 border border-border"
             >
               {t.music}
             </a>
-            <a 
-              href="mailto:info@loelash.com?subject=Services Inquiry"
+            <a
+              href={mailtoLink('Services Inquiry')}
               className="px-4 py-2 rounded-full bg-background text-foreground hover:bg-muted transition-all duration-200 border border-border"
             >
               {t.services}
             </a>
-            <a 
-              href="mailto:info@loelash.com?subject=Contact Request"
+            <a
+              href={mailtoLink('Contact Request')}
               className="px-4 py-2 rounded-full bg-background text-foreground hover:bg-muted transition-all duration-200 border border-border"
             >
               {t.contact}
@@ -68,15 +69,13 @@ export const Header = ({ language, onLanguageChange }: HeaderProps) => {
             </div>
 
             {/* CTA Button */}
-            <Button 
-              variant="cta" 
+            <Button
+              variant="cta"
               size="sm"
               asChild
               className="rounded-full"
             >
-              <a href="mailto:info@loelash.com?subject=Let's Work Together!">
-                {t.cta}
-              </a>
+              <a href={mailtoLink("Let's Work Together!")}>{t.cta}</a>
             </Button>
           </div>
         </nav>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { Language, heroTranslations } from "@/lib/i18n";
+import { mailtoLink } from "@/lib/utils";
 
 interface HeroSectionProps {
   language: Language;
@@ -54,7 +55,9 @@ const MobileServiceSection = ({ quadrant, index, activeIndex, onVisible }: Mobil
     >
       <div
         className={`relative z-10 max-w-xs p-8 text-white transition-all duration-700 transform ${stateClass}`}
-        onClick={() => window.location.href = `mailto:info@loelash.com?subject=${quadrant.service.title} Service Inquiry`}
+        onClick={() =>
+          (window.location.href = mailtoLink(`${quadrant.service.title} Service Inquiry`))
+        }
       >
         <h3 className="text-3xl font-bold mb-4">{quadrant.service.title}</h3>
         <p className="text-base mb-6 opacity-90">{quadrant.service.description}</p>
@@ -167,7 +170,9 @@ export const HeroSection = ({ language }: HeroSectionProps) => {
               'bottom-0 right-0'
             }`}
             onMouseEnter={() => handleQuadrantEnter(quadrant.id)}
-            onClick={() => window.location.href = `mailto:info@loelash.com?subject=${quadrant.service.title} Service Inquiry`}
+            onClick={() =>
+              (window.location.href = mailtoLink(`${quadrant.service.title} Service Inquiry`))
+            }
           >
             {/* Service Content Overlay - Only visible when any quadrant is hovered */}
             <div className={`absolute inset-0 transition-all duration-500 ${

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -118,10 +118,10 @@ export const footerTranslations = {
 export const aboutTranslations = {
   en: {
     title: 'About',
-    text: "I'm Lorenzo (aka Loelash) - a London-based multi-instrumentalist, producer, DJ, and certified Apple Trainer. With over a decade of experience in music creation and performance, I blend classical training with modern production skills to support artists at every stage of their journey. Whether it's through tutoring, session work, engineering, or promotion, my mission"
+    text: "I'm Lorenzo (aka Loelash) - a London-based multi-instrumentalist, producer, DJ, and certified Apple Trainer. With over a decade of experience in music creation and performance, I blend classical training with modern production skills to support artists at every stage of their journey. Whether it's through tutoring, session work, engineering, or promotion, my mission is to help you unlock your full creative potential."
   },
   it: {
     title: 'Chi Sono',
-    text: 'Sono Lorenzo (alias Loelash) - un polistrumentista, produttore, DJ e Apple Trainer certificato con base a Londra. Con oltre un decennio di esperienza nella creazione e performance musicale, unisco la formazione classica alle moderne competenze di produzione per supportare gli artisti in ogni fase del loro percorso. Che si tratti di lezioni, session work, engineering o promozione, la mia missione'
+    text: 'Sono Lorenzo (alias Loelash) - un polistrumentista, produttore, DJ e Apple Trainer certificato con base a Londra. Con oltre un decennio di esperienza nella creazione e performance musicale, unisco la formazione classica alle moderne competenze di produzione per supportare gli artisti in ogni fase del loro percorso. Che si tratti di lezioni, session work, engineering o promozione, la mia missione è aiutarti a sbloccare il tuo pieno potenziale creativo.'
   }
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,9 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export const CONTACT_EMAIL = 'info@loelash.com'
+
+export function mailtoLink(subject: string) {
+  return `mailto:${CONTACT_EMAIL}?subject=${encodeURIComponent(subject)}`
+}


### PR DESCRIPTION
## Summary
- add `CONTACT_EMAIL` and `mailtoLink` helper
- use `mailtoLink` in `Header` and `HeroSection`
- finish the `about` translation text

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688785b654dc8320ab0a5defa963f5be