### PR TITLE
Improve hero image alt text

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -118,7 +118,7 @@ export const HeroSection = ({ language }: HeroSectionProps) => {
             src={heroImage}
             className="h-full w-full object-cover transition-all duration-700"
             style={{ filter: `blur(${8 * scrollProgress}px)` }}
-            alt="Hero"
+            alt={t.imageAlt}
           />
           <div
             className="absolute inset-0 bg-black transition-opacity duration-700"

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -28,6 +28,7 @@ export const subHeaderTranslations = {
 
 export const heroTranslations = {
   en: {
+    imageAlt: 'Recording studio with synthesizers and mixing desk',
     services: {
       mixing: {
         title: 'Music Tutoring & Production Coaching',
@@ -52,6 +53,7 @@ export const heroTranslations = {
     }
   },
   it: {
+    imageAlt: 'Studio di registrazione con sintetizzatori e mixer',
     services: {
       mixing: {
         title: 'Lezioni di Musica & Coaching di Produzione',


### PR DESCRIPTION
## Summary
- add hero image alt text translations in English and Italian
- use the new alt text in `HeroSection`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68878786ed5483209209402decf27d86