### PR TITLE
Localize NotFound page

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -125,3 +125,14 @@ export const aboutTranslations = {
     text: 'Sono Lorenzo (alias Loelash) - un polistrumentista, produttore, DJ e Apple Trainer certificato con base a Londra. Con oltre un decennio di esperienza nella creazione e performance musicale, unisco la formazione classica alle moderne competenze di produzione per supportare gli artisti in ogni fase del loro percorso. Che si tratti di lezioni, session work, engineering o promozione, la mia missione è aiutarti a sbloccare il tuo pieno potenziale creativo.'
   }
 };
+
+export const notFoundTranslations = {
+  en: {
+    message: 'Oops! Page not found',
+    cta: 'Return to Home'
+  },
+  it: {
+    message: 'Ops! Pagina non trovata',
+    cta: 'Torna alla Home'
+  }
+};

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,5 +1,6 @@
 import { useLocation } from "react-router-dom";
 import { useEffect } from "react";
+import { Language, notFoundTranslations } from "@/lib/i18n";
 
 const NotFound = () => {
   const location = useLocation();
@@ -11,13 +12,16 @@ const NotFound = () => {
     );
   }, [location.pathname]);
 
+  const language: Language = navigator.language.startsWith("it") ? "it" : "en";
+  const t = notFoundTranslations[language];
+
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-100">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
-        <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
+        <p className="text-xl text-gray-600 mb-4">{t.message}</p>
         <a href="/" className="text-blue-500 hover:text-blue-700 underline">
-          Return to Home
+          {t.cta}
         </a>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add Italian and English strings for the 404 page
- show translated text on the `NotFound` page using browser language detection

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6887875721d08320801eed297c0d3fd4