### PR TITLE
Add theme toggle

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { ThemeToggle } from "@/components/ThemeToggle";
 import { Language, headerTranslations } from "@/lib/i18n";
 import { mailtoLink } from "@/lib/utils";
 
@@ -66,17 +67,19 @@ export const Header = ({ language, onLanguageChange }: HeaderProps) => {
               >
                 IT
               </button>
-            </div>
+          </div>
 
-            {/* CTA Button */}
-            <Button
-              variant="cta"
-              size="sm"
-              asChild
-              className="rounded-full"
-            >
-              <a href={mailtoLink("Let's Work Together!")}>{t.cta}</a>
-            </Button>
+          <ThemeToggle language={language} />
+
+          {/* CTA Button */}
+          <Button
+            variant="cta"
+            size="sm"
+            asChild
+            className="rounded-full"
+          >
+            <a href={mailtoLink("Let's Work Together!")}>{t.cta}</a>
+          </Button>
           </div>
         </nav>
       </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "react";
+import { useTheme } from "next-themes";
+import { Moon, Sun } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { headerTranslations, Language } from "@/lib/i18n";
+
+interface ThemeToggleProps {
+  language: Language;
+}
+
+export const ThemeToggle = ({ language }: ThemeToggleProps) => {
+  const { theme = "light", setTheme } = useTheme();
+  const [mounted, setMounted] = useState(false);
+  const t = headerTranslations[language];
+
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (theme === "dark") {
+      document.documentElement.classList.add("dark");
+    } else {
+      document.documentElement.classList.remove("dark");
+    }
+  }, [theme]);
+
+  if (!mounted) return null;
+
+  const toggleTheme = () => {
+    setTheme(theme === "dark" ? "light" : "dark");
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label={t.theme}
+    >
+      {theme === "dark" ? (
+        <Sun className="h-5 w-5" />
+      ) : (
+        <Moon className="h-5 w-5" />
+      )}
+    </Button>
+  );
+};

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -5,13 +5,15 @@ export const headerTranslations = {
     music: 'Music',
     services: 'Services',
     contact: 'Contact',
-    cta: "Let's Work!"
+    cta: "Let's Work!",
+    theme: 'Toggle theme'
   },
   it: {
     music: 'Musica',
     services: 'Servizi',
     contact: 'Contatto',
-    cta: 'Lavoriamo!'
+    cta: 'Lavoriamo!',
+    theme: 'Cambia tema'
   }
 };
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,10 @@
 import { createRoot } from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'
+import { ThemeProvider } from 'next-themes'
 
-createRoot(document.getElementById("root")!).render(<App />);
+createRoot(document.getElementById("root")!).render(
+  <ThemeProvider storageKey="theme" defaultTheme="light">
+    <App />
+  </ThemeProvider>
+)


### PR DESCRIPTION
## Summary
- add a new `ThemeToggle` component
- insert the theme toggle in the header
- store translations for the toggle label
- wrap the app in `ThemeProvider` for persistent theme

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6887879f546c83208d7e5bdf5b1ea13c