### PR TITLE
Invert about & companies colors

### DIFF
--- a/src/components/AboutSection.tsx
+++ b/src/components/AboutSection.tsx
@@ -10,10 +10,10 @@ export const AboutSection = ({ language }: AboutSectionProps) => {
   const t = translations[language];
 
   return (
-    <section className="py-16">
+    <section className="py-16 bg-primary text-primary-foreground">
       <div className="container mx-auto px-6 flex flex-col md:flex-row gap-8">
         <h2 className="text-2xl md:text-3xl font-semibold md:w-1/4">{t.title}</h2>
-        <p className="text-base text-muted-foreground md:w-3/4 max-w-prose">
+        <p className="text-base md:w-3/4 max-w-prose">
           {t.text}
         </p>
       </div>

--- a/src/components/TrustSection.tsx
+++ b/src/components/TrustSection.tsx
@@ -10,19 +10,19 @@ export const TrustSection = ({ language }: TrustSectionProps) => {
   const t = translations[language];
 
   return (
-    <section className="py-16 bg-muted/30">
+    <section className="py-16 bg-primary text-primary-foreground">
       <div className="container mx-auto px-6">
         <div className="text-center mb-12">
-          <h2 className="text-2xl font-semibold text-foreground mb-8">
+          <h2 className="text-2xl font-semibold mb-8">
             {t.title}
           </h2>
         </div>
         
         <div className="flex flex-wrap justify-center items-center gap-8 md:gap-12 opacity-60">
           {t.clients.map((client, index) => (
-            <div 
+            <div
               key={index}
-              className="text-sm md:text-base font-medium text-muted-foreground hover:text-foreground transition-colors duration-200"
+              className="text-sm md:text-base font-medium text-primary-foreground/70 hover:text-primary-foreground transition-colors duration-200"
             >
               {client}
             </div>


### PR DESCRIPTION
## Summary
- invert background/text colors for `TrustSection`
- invert background/text colors for `AboutSection`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6887895a7e6883208e3a77d59d7f5f1e