### PR TITLE
Add additional clients

### DIFF
--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -88,7 +88,21 @@ export const trustTranslations = {
       'Independent Artists',
       'Emerging Talents',
       'Major Labels',
-      'Music Producers'
+      'Music Producers',
+      'Pekodjinn',
+      'DijahSB',
+      'Brenda & Maria Manuela',
+      'Palmaria',
+      'Taite Imogen',
+      'The Last Skeptik',
+      'Stanzah!',
+      'Native Instruments',
+      'Nike',
+      'Arts Council of England',
+      'RedBull',
+      'pointblank Music School',
+      'The Greater Goods',
+      'Pirate Studios'
     ]
   },
   it: {
@@ -99,7 +113,21 @@ export const trustTranslations = {
       'Artisti Indipendenti',
       'Talenti Emergenti',
       'Etichette Principali',
-      'Produttori Musicali'
+      'Produttori Musicali',
+      'Pekodjinn',
+      'DijahSB',
+      'Brenda & Maria Manuela',
+      'Palmaria',
+      'Taite Imogen',
+      'The Last Skeptik',
+      'Stanzah!',
+      'Native Instruments',
+      'Nike',
+      "Arts Council of England",
+      'RedBull',
+      'pointblank Music School',
+      'The Greater Goods',
+      'Pirate Studios'
     ]
   }
 };


### PR DESCRIPTION
## Summary
- add more artist and company names to the Trust section translations

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688789aea18c8320a8b2fb7889699e6b