### PR TITLE
Add SEO enhancements for English and Italian

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
+  <html lang="en">
+    <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>LOELASH - Music Producer & Studio</title>
@@ -14,8 +14,11 @@
 
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@lovable_dev" />
-    <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
-  </head>
+      <meta name="twitter:image" content="https://lovable.dev/opengraph-image-p98pqg.png" />
+      <link rel="canonical" href="/" />
+      <link rel="alternate" hreflang="en" href="/?lang=en" />
+      <link rel="alternate" hreflang="it" href="/?lang=it" />
+    </head>
 
   <body>
     <div id="root"></div>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -12,3 +12,4 @@ Allow: /
 
 User-agent: *
 Allow: /
+Sitemap: /sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://loelash.com/</loc>
+    <changefreq>weekly</changefreq>
+    <priority>0.8</priority>
+  </url>
+</urlset>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -1,5 +1,16 @@
 export type Language = 'en' | 'it';
 
+export const seoTranslations = {
+  en: {
+    title: 'LOELASH - Music Producer & Studio',
+    description: 'Professional mixing, mastering, and music production services. Craft your sound, shape your future.'
+  },
+  it: {
+    title: 'LOELASH - Producer musicale & Studio',
+    description: 'Servizi professionali di mixing, mastering e produzione musicale. Crea il tuo suono, modella il tuo futuro.'
+  }
+};
+
 export const headerTranslations = {
   en: {
     music: 'Music',

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Header } from "@/components/Header";
 import { SubHeader } from "@/components/SubHeader";
 import { HeroSection } from "@/components/HeroSection";
@@ -6,9 +6,20 @@ import { TrustSection } from "@/components/TrustSection";
 import { AboutSection } from "@/components/AboutSection";
 import { Footer } from "@/components/Footer";
 import type { Language } from "@/lib/i18n";
+import { seoTranslations } from "@/lib/i18n";
 
 const Index = () => {
   const [language, setLanguage] = useState<Language>('en');
+
+  useEffect(() => {
+    const seo = seoTranslations[language];
+    document.documentElement.lang = language;
+    document.title = seo.title;
+    const metaDesc = document.querySelector('meta[name="description"]');
+    if (metaDesc) {
+      metaDesc.setAttribute('content', seo.description);
+    }
+  }, [language]);
 
   return (
     <div className="min-h-screen bg-background">


### PR DESCRIPTION
## Summary
- provide SEO translations
- update meta tags dynamically based on language
- add canonical and alternate link tags
- generate a sitemap and link to it in `robots.txt`

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68878b171bdc8320a166201903fa5f5a