### PR TITLE
Adjust hero width and client section color

### DIFF
--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -142,7 +142,7 @@ export const HeroSection = ({ language }: HeroSectionProps) => {
     <section className="relative flex justify-center h-screen min-h-[70vh] overflow-hidden">
       {/* Main Hero Image Container */}
       <div
-        className="relative w-full h-full max-w-screen-lg mx-auto cursor-none"
+        className="relative w-full h-full max-w-screen-xl mx-auto cursor-none"
         onMouseLeave={handleMouseLeave}
       >
         {/* Base Image */}

--- a/src/components/TrustSection.tsx
+++ b/src/components/TrustSection.tsx
@@ -10,7 +10,7 @@ export const TrustSection = ({ language }: TrustSectionProps) => {
   const t = translations[language];
 
   return (
-    <section className="py-16 bg-white text-black">
+    <section className="py-16 bg-background text-foreground">
       <div className="container mx-auto px-6">
         <div className="text-center mb-12">
           <h2 className="text-2xl font-semibold mb-8">


### PR DESCRIPTION
## Summary
- match TrustSection background color to header
- enlarge hero image container width

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68878f1792bc8320b6c14bdfa56986c6