### PR TITLE
Add footer credits

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -73,7 +73,20 @@ export const Footer = ({ language, onContact }: FooterProps) => {
             })}
           </div>
         </div>
-        {/* ...existing code... */}
+        <div className="mt-8 text-center text-sm space-y-2">
+          <p>{t.rights}</p>
+          <p>
+            {t.credits}{' '}
+            <a
+              href="https://www.soundniccolo.com"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline"
+            >
+              {t.creditsLink}
+            </a>
+          </p>
+        </div>
       </div>
     </footer>
   );

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -147,12 +147,16 @@ export const footerTranslations = {
   en: {
     contact: 'Get in Touch',
     rights: '© 2024 LOELASH. All rights reserved.',
-    email: 'info@loelash.com'
+    email: 'info@loelash.com',
+    credits: 'Website created by',
+    creditsLink: 'Sound Niccolò Studio'
   },
   it: {
     contact: 'Mettiti in Contatto',
     rights: '© 2024 LOELASH. Tutti i diritti riservati.',
-    email: 'info@loelash.com'
+    email: 'info@loelash.com',
+    credits: 'Sito realizzato da',
+    creditsLink: 'Sound Niccolò Studio'
   }
 };
 


### PR DESCRIPTION
## Summary
- show rights and credits lines in `Footer`
- update translations with `credits` text for English and Italian

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68879140fa3483209e9f36ca959b3926