### PR TITLE
Add scroll-to-top on header logo

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -17,11 +17,17 @@ export const Header = ({ language, onLanguageChange, onContact }: HeaderProps) =
         <nav className="flex items-center justify-between">
           {/* Logo */}
           <div className="flex items-center">
-            <img 
-              src="/lovable-uploads/56b6f8cb-ea6a-416d-9253-07f2c388031e.png" 
-              alt="LOELASH" 
-              className="h-8 w-auto"
-            />
+            <button
+              onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+              aria-label="Scroll to top"
+              className="p-0 border-0 bg-transparent cursor-pointer"
+            >
+              <img
+                src="/lovable-uploads/56b6f8cb-ea6a-416d-9253-07f2c388031e.png"
+                alt="LOELASH"
+                className="h-8 w-auto"
+              />
+            </button>
           </div>
 
           {/* Navigation */}


### PR DESCRIPTION
## Summary
- make the header logo clickable
- clicking the logo smoothly scrolls to the top

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68879a0412488320a1531c9aee888619