### PR TITLE
Add animated brand & artist scrollers

### DIFF
--- a/src/components/TrustSection.tsx
+++ b/src/components/TrustSection.tsx
@@ -17,16 +17,53 @@ export const TrustSection = ({ language }: TrustSectionProps) => {
             {t.title}
           </h2>
         </div>
-        
-        <div className="flex flex-wrap justify-center items-center gap-8 md:gap-12 opacity-60">
-          {t.clients.map((client, index) => (
-            <div
-              key={index}
-              className="text-sm md:text-base font-medium text-black/70 hover:text-black transition-colors duration-200"
-            >
-              {client}
+
+        <div className="space-y-6">
+          {/* Brands Row */}
+          <div className="overflow-hidden">
+            <div className="flex items-center gap-8 md:gap-12 whitespace-nowrap opacity-60 animate-scroll-left">
+              {t.brands.map((client, index) => (
+                <div
+                  key={`brand-${index}`}
+                  className="text-sm md:text-base font-medium text-black/70 hover:text-black transition-colors duration-200"
+                >
+                  {client}
+                </div>
+              ))}
+              {t.brands.map((client, index) => (
+                <div
+                  key={`brand-dup-${index}`}
+                  aria-hidden="true"
+                  className="text-sm md:text-base font-medium text-black/70 hover:text-black transition-colors duration-200"
+                >
+                  {client}
+                </div>
+              ))}
             </div>
-          ))}
+          </div>
+
+          {/* Artists Row */}
+          <div className="overflow-hidden">
+            <div className="flex items-center gap-8 md:gap-12 whitespace-nowrap opacity-60 animate-scroll-right">
+              {t.artists.map((client, index) => (
+                <div
+                  key={`artist-${index}`}
+                  className="text-sm md:text-base font-medium text-black/70 hover:text-black transition-colors duration-200"
+                >
+                  {client}
+                </div>
+              ))}
+              {t.artists.map((client, index) => (
+                <div
+                  key={`artist-dup-${index}`}
+                  aria-hidden="true"
+                  className="text-sm md:text-base font-medium text-black/70 hover:text-black transition-colors duration-200"
+                >
+                  {client}
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -93,52 +93,58 @@ export const heroTranslations = {
 export const trustTranslations = {
   en: {
     title: 'Trusted by artists worldwide',
-    clients: [
-      'Universal Music Group',
-      'Sony Music',
-      'Independent Artists',
-      'Emerging Talents',
-      'Major Labels',
-      'Music Producers',
+    brands: [
+      'Soho House',
+      'Native Instruments',
+      'Nike',
+      'The Greater Goods Co.',
+      'Liverpool Sound City',
+      'Ace Hotel',
+      'Arts Council of England',
+      'RedBull',
+      'Hard Rock',
+      'VICE',
+      'The Hoxton',
+      'Pirate Studios',
+      'Molto Music Group',
+      'pointblank Music School'
+    ],
+    artists: [
       'Pekodjinn',
       'DijahSB',
-      'Brenda & Maria Manuela',
+      'Brenda & MM',
       'Palmaria',
       'Taite Imogen',
       'The Last Skeptik',
-      'Stanzah!',
-      'Native Instruments',
-      'Nike',
-      'Arts Council of England',
-      'RedBull',
-      'pointblank Music School',
-      'The Greater Goods',
-      'Pirate Studios'
+      'Stanzah!'
     ]
   },
   it: {
     title: 'La fiducia di artisti in tutto il mondo',
-    clients: [
-      'Universal Music Group',
-      'Sony Music',
-      'Artisti Indipendenti',
-      'Talenti Emergenti',
-      'Etichette Principali',
-      'Produttori Musicali',
+    brands: [
+      'Soho House',
+      'Native Instruments',
+      'Nike',
+      'The Greater Goods Co.',
+      'Liverpool Sound City',
+      'Ace Hotel',
+      'Arts Council of England',
+      'RedBull',
+      'Hard Rock',
+      'VICE',
+      'The Hoxton',
+      'Pirate Studios',
+      'Molto Music Group',
+      'pointblank Music School'
+    ],
+    artists: [
       'Pekodjinn',
       'DijahSB',
-      'Brenda & Maria Manuela',
+      'Brenda & MM',
       'Palmaria',
       'Taite Imogen',
       'The Last Skeptik',
-      'Stanzah!',
-      'Native Instruments',
-      'Nike',
-      "Arts Council of England",
-      'RedBull',
-      'pointblank Music School',
-      'The Greater Goods',
-      'Pirate Studios'
+      'Stanzah!'
     ]
   }
 };

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -71,29 +71,39 @@ export default {
 				md: 'calc(var(--radius) - 2px)',
 				sm: 'calc(var(--radius) - 4px)'
 			},
-			keyframes: {
-				'accordion-down': {
-					from: {
-						height: '0'
-					},
-					to: {
-						height: 'var(--radix-accordion-content-height)'
-					}
-				},
-				'accordion-up': {
-					from: {
-						height: 'var(--radix-accordion-content-height)'
-					},
-					to: {
-						height: '0'
-					}
-				}
-			},
-			animation: {
-				'accordion-down': 'accordion-down 0.2s ease-out',
-				'accordion-up': 'accordion-up 0.2s ease-out'
-			}
-		}
-	},
-	plugins: [require("tailwindcss-animate")],
+                        keyframes: {
+                                'accordion-down': {
+                                        from: {
+                                                height: '0'
+                                        },
+                                        to: {
+                                                height: 'var(--radix-accordion-content-height)'
+                                        }
+                                },
+                                'accordion-up': {
+                                        from: {
+                                                height: 'var(--radix-accordion-content-height)'
+                                        },
+                                        to: {
+                                                height: '0'
+                                        }
+                                },
+                                'scroll-left': {
+                                        from: { transform: 'translateX(0)' },
+                                        to: { transform: 'translateX(-50%)' }
+                                },
+                                'scroll-right': {
+                                        from: { transform: 'translateX(-50%)' },
+                                        to: { transform: 'translateX(0)' }
+                                }
+                        },
+                        animation: {
+                                'accordion-down': 'accordion-down 0.2s ease-out',
+                                'accordion-up': 'accordion-up 0.2s ease-out',
+                                'scroll-left': 'scroll-left 30s linear infinite',
+                                'scroll-right': 'scroll-right 30s linear infinite'
+                        }
+                }
+        },
+        plugins: [require("tailwindcss-animate")],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- split TrustSection content into brand and artist rows
- animate the rows in opposite scrolling directions
- update translations for brands and artists
- extend Tailwind with new scroll animations

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68879a5759388320970888ab22a15a6f